### PR TITLE
Add `use_contact` field support to Transfers API

### DIFF
--- a/zengapay/client.py
+++ b/zengapay/client.py
@@ -70,8 +70,9 @@ class ZengaPayAPI(ClientInterface):
 
     def request(self, method, url, post_data=None):
         self.auth_token = self.get_auth_token()
+        # Turning `data` attribute to json since we are posting json data
         request = Request(
-            method, url, data=post_data, auth=ZengaPayAuth(self.auth_token)
+            method, url, json=post_data, auth=ZengaPayAuth(self.auth_token)
         )
 
         prep_req = self._session.prepare_request(request)

--- a/zengapay/transfer.py
+++ b/zengapay/transfer.py
@@ -1,5 +1,6 @@
 from .client import ZengaPayAPI
 from .utils import validate_number, validate_phone_number, validate_string
+import json
 
 
 class Transfers(ZengaPayAPI):
@@ -10,9 +11,19 @@ class Transfers(ZengaPayAPI):
             payload.get("external_reference")
         )
         payload["narration"] = validate_string(payload.get("narration"))
+        
+        # Add `use_contact` field since it is now required according to the API
+        # https://developers.zengapay.com/#the-transfer-request-object
+        if payload["use_contact"] is None:
+            raise Exception("`use_contact` field is required")
+        elif payload["use_contact"] == True:
+            if payload["contact_id"] is None:
+                raise Exception("`contact_id` field is required when `use_contact` is True")
+        
+        json_payload = json.dumps(payload)
 
         url = f"{self.config.base_url}/transfers"
-        res = self.request("POST", url, post_data=payload)
+        res = self.request("POST", url, post_data=json_payload)
 
         return res.json()
 


### PR DESCRIPTION
Add `use_contact` field since it is now required according to the API
Currently if you use the `zengapay` python client to request for a transfer. The `use_contact` field is either not posted or is posted wrongly and the request returns an error.
https://developers.zengapay.com/#the-transfer-request-object
Nobody seemed to answer this issue #7 so i just edited the source code my self

## Reproduce error

__`transfer.py`__
```py
import os
from zengapay import Collections, Transfers


config = {
    "ZENGAPAY_ENVIRONMENT": "sandbox",
    "ZENGAPAY_BASE_URL": "https://api.sandbox.zengapay.com/v1",
    "ZENGAPAY_USER_API_TOKEN": "<API-TOKEN>"
}

collection_client = Collections(config)
transfer_client = Transfers(config)

payload = {
    # The phone number that the collection request is intended for.
    "msisdn": "<phone number>",
    "amount": 30000,  # The collection request amount.
    # Internal description or reason for this collection request and must be unique for every request.
    "external_reference": f"loantrans",
    # Textual narrative describing the transaction.
    "narration": f"Get loan trans  -",
    "use_contact": False
}
resp = transfer_client.transfer(payload)
print(resp)
```
__Error in console__

```
/home/junior/dev/github/zengapay/.venv/lib/python3.10/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.sandbox.zengapay.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
{'use_contact': ['The use contact field must be true or false.'], 'contact_id': ['The contact id field is required.']}
```
